### PR TITLE
Allow a user to specify a personal ssh key and user

### DIFF
--- a/aws-ssh-config
+++ b/aws-ssh-config
@@ -58,7 +58,13 @@ def main():
                         help='Append the region name at the end of the concatenation')
     parser.add_argument('--private', action='store_true',
                         help='Use private IP addresses (public are used by default)')
+    parser.add_argument('--ssh-key', help='Personal SSH key that should be used for connection. Default=~/.ssh/optiprod.pem')
+    parser.add_argument('--ssh-user', help='Personal SSH user that should be used for connection. If you choose ssh-key you must also specify this argument.')
     args = parser.parse_args()
+
+    if (args.ssh_key and not args.ssh_user):
+       print "When you specify a personal ssh key please also define your ssh user!"
+       sys.exit(1)
 
     instances = {}
     counts_total = {}
@@ -122,13 +128,19 @@ def main():
             print '    HostName ' + ip
 
             try:
-                if amis[instance.image_id] is not None:
+                if args.ssh_user:
+                    print '    User ' + args.ssh_user
+                elif amis[instance.image_id] is not None:
                     print '    User ' + amis[instance.image_id]
             except:
                 sys.stderr.write("Can't find user for host %s" % id)
                 pass
 
-            print '    IdentityFile ~/.ssh/' + instance.key_name + '.pem'
+            if args.ssh_key:
+                print '    IdentityFile %s' % args.ssh_key
+            else:
+                print '    IdentityFile ~/.ssh/' + instance.key_name + '.pem'
+
             # just for me, removing this is usually a good choice
             print '    StrictHostKeyChecking no'
             print

--- a/stack-ssh.sh
+++ b/stack-ssh.sh
@@ -15,8 +15,10 @@ if [ -e "$tgt" ]; then
     cp $tgt $backup
 fi
 
+[ ! -z "$STACK_SSH_KEY" ] && ssh_key_arg="--ssh-key ${STACK_SSH_KEY}"
+[ ! -z "$STACK_SSH_USER" ] && ssh_user_arg="--ssh-user ${STACK_SSH_USER}"
 
 echo "Populating $tgt with AWS EC2 instances"
-aws-ssh-config --tags "aws:cloudformation:stack-name,sparta-role,Name" | tee "$tgt"
+aws-ssh-config --tags "aws:cloudformation:stack-name,sparta-role,Name" $ssh_user_arg $ssh_key_arg | tee "$tgt"
 echo "Done."
 


### PR DESCRIPTION
We are (slowly) moving toward using personal SSH keys to access our environment instead of the one-master key, also known as `optiprod.pem`.

The changes in this PR allow specifying two environment variables: `STACK_SSH_KEY` and `STACK_SSH_USER` to generate the ssh_config files with a personal user and key instead of the global one.
